### PR TITLE
ci(github): add timeouts of 30 minutes to test actions

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,6 +7,7 @@ jobs:
   release_npm:
     runs-on: ubuntu-latest
     name: Publish Package to NPM
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ jobs:
   test_suite:
     runs-on: ${{ matrix.os }}
     name: Test - ${{ matrix.os }} - Node ${{ matrix.node }}
+    timeout-minutes: 30
     strategy:
       matrix:
         node: [10, 12]


### PR DESCRIPTION
windows builds reguarly timeout with a default timeout of 3h