### PR TITLE
fix(readme): use ES2018 as tsc target

### DIFF
--- a/packages/readme/tsconfig.json
+++ b/packages/readme/tsconfig.json
@@ -4,7 +4,7 @@
         "outDir": "./dist",
         "rootDir": "./src",
         "declaration": false,
-        "target": "ESNext",
+        "target": "ES2018",
         "module": "ES2020",
         "moduleResolution": "Node",
         "esModuleInterop": true


### PR DESCRIPTION
currently ESNext as target is not recommended

fix #777