### PR TITLE
fix(ico): remove empty export

### DIFF
--- a/packages/ico/src/dir-entry/index.ts
+++ b/packages/ico/src/dir-entry/index.ts
@@ -11,5 +11,4 @@ export {
     IIcoData,
     ImageFormat,
 } from './dir-entry';
-export { } from './create-entry';
 export { readDirEntry } from './read-dir-entry';


### PR DESCRIPTION
Unused empty export. Throws when used with dts definiton minification

fix #1054