### PR TITLE
feat(sudoku): only export esm module

### DIFF
--- a/packages/sudoku/package.json
+++ b/packages/sudoku/package.json
@@ -2,18 +2,17 @@
     "name": "@donmahallem/sudoku",
     "version": "0.6.1",
     "description": "Sudoku Solver",
-    "main": "./dist/cjs/index.cjs",
-    "types": "./dist/types/index.d.ts",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
     "private": false,
     "type": "module",
     "exports": {
-        "require": "./dist/cjs/index.cjs",
-        "import": "./dist/esm/index.mjs",
-        "types": "./dist/types/index.d.ts"
+        "import": "./dist/index.mjs",
+        "types": "./dist/index.d.ts"
     },
     "typedocMain": "./src/index.ts",
     "scripts": {
-        "build": "rollup -c rollup.config.mjs",
+        "build": "tsc -p tsconfig.lib.json",
         "build:readme": "npx @appnest/readme generate --input ../package_readme_blueprint.md --config readme_config.json",
         "test": "mocha --config ../../.mocharc.json",
         "test:coverage": "c8 --config ../../.nycrc.json npm run test",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "moduleResolution": "bundler",
         "strictNullChecks": true,
         "noUnusedLocals": true,
+        "skipLibCheck": true,
         "lib": [
             "ES2022"
         ]


### PR DESCRIPTION
removed CommonJS export

BREAKING CHANGE: no commonjs export anymore only esm